### PR TITLE
Use correct URL handling method in app delegate

### DIFF
--- a/passionProject/AppDelegate.swift
+++ b/passionProject/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             auth.sessionUserDefaultsKey = "current session"
         return true
     }
-    func application(_ application: UIApplication, open url: URL, sourceApplication: String?, annotation: Any) -> Bool {
+    func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
         //called when user signs into spotify. session data saved into user defaults, then notification posted to call updateAfterFirstLogin in ViewController.swift.
         // 2- check if app can handle redirect URL
         if auth.canHandle(auth.redirectURL) {


### PR DESCRIPTION
When the app launches to handle a URL (as in the case of a callback from Spotify login), the method that's called is `application(_:open:options:)`. The crash was happening because this method was missing from the implementation.